### PR TITLE
Feat : 음원 상세페이지 - 음원 정보, 리뷰 작성/수정/삭제

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "workbench.colorTheme": "Visual Studio Dark"
-}

--- a/music_detail.html
+++ b/music_detail.html
@@ -75,53 +75,141 @@
         <div class="container position-relative">
             <!-- 여기 안에서 작업 -->
             
-            <div class='main' >
-                <section class='sec section_recommend_music' id="music_detail">
-                    <div class="section_header" style="width:80%">
-                        <h2 class="section_title highlight">Track #number</h2>
-                    </div>
-                    <div class="container-2 text-center">
-                        <div class="music_content row">
-                            <div class="col-md-4">
-                                <img src="https://i.scdn.co/image/ab67706f00000002381ef12e384968316222cbd5" class="img-fluid rounded-start" alt="...">
-                            </div>
-                            <div class="col-md-4">
-                                <div class="card-body">
-                                <p class="text-muted">가수 : Rihanna</p>
-                                <p class="text-muted">가수 : Rihanna</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="review">
-                        <div class="section_header">
-                            <h2 class="section_title highlight">리뷰를 작성해주세요 :)</h2>
-                        </div>
-                        <div class="form-floating">
-                            <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2" style="height: 100px"></textarea>
-                            <label for="floatingTextarea">댓글을 남겨주세요!</label>
-                        </div>
-                        <div class="button_write">
-                            <button type="button" class="btn_review_submit btn btn-success btn-lg">등록하기</button>
-                        </div>
-                    </div>
-                </section>
+            <div class='main' style="width:100%">
                 
-                <hr width = "80%" color = "#1ED760">
+                <div class="container-2 text-center" id="music_detail">
+                    <div class="music_content row">
+                        <div class="col-md-4">
+                            <img src="https://i.scdn.co/image/ab67706f00000002381ef12e384968316222cbd5" class="img-fluid rounded-start" alt="...">
+                            <br/>
+                            <h1 class="text-muted">가수 : Rihanna</h1>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="review">
+                    <div class="section_review_header">
+                        <h2 class="write_review section_title highlight">리뷰를 작성해주세요 :)</h2>
+                        <input type="text" id="content" class="form-control" placeholder="내용">
+                        <br/>
+                        <input type="text" id="grade" class="form-control" placeholder="평점">
+                    </div>
+                    <div class="button_write">
+                        <button type="button" onclick="handleCreateReview()" class="btn_review_submit btn btn-success btn-lg">등록하기</button>
+                    </div>
+                </div>
+                
+                
+                
                 <section class='sec section_review_music' >
-                    <div class="section_header" style="width:80%;">
+                    <hr color = "#1ED760">
+                    <div class="section_header">
                         <h2 class="section_title highlight">리뷰 목록</h2>
                     </div>
                     <ol class="list-group list-group-numbered" id="review_list">
-                        <li class="d-flex justify-content-between align-items-start">
-                          <div class="ms-2 me-auto">
-                            <div class="fw-bold">작성자</div>
-                            리뷰 내용
-                          </div>
-                          <span class="badge bg-primary rounded-pill">별점</span>
+                        <li class="d-flex justify-content-between align-items-start mb-5">
+                            <div class="row">
+                                <div class="col-10">
+                                    <div class="fw-bold flex mb-1">
+                                        <span class="user">작성자</span> 
+                                        <div class="music_card_grade" style="margin-left: 16px;">
+                                            <span class="grade">3.5</span>
+                                            <div class="starpoint_wrap">
+                                                <div class="starpoint_box star_70">
+                                                <label for="starpoint_1" class="label_star" title="0.5"><span class="blind">0.5점</span></label>
+                                                <label for="starpoint_2" class="label_star" title="1"><span class="blind">1점</span></label>
+                                                <label for="starpoint_3" class="label_star" title="1.5"><span class="blind">1.5점</span></label>
+                                                <label for="starpoint_4" class="label_star" title="2"><span class="blind">2점</span></label>
+                                                <label for="starpoint_5" class="label_star" title="2.5"><span class="blind">2.5점</span></label>
+                                                <label for="starpoint_6" class="label_star" title="3"><span class="blind">3점</span></label>
+                                                <label for="starpoint_7" class="label_star" title="3.5"><span class="blind">3.5점</span></label>
+                                                <label for="starpoint_8" class="label_star" title="4"><span class="blind">4점</span></label>
+                                                <label for="starpoint_9" class="label_star" title="4.5"><span class="blind">4.5점</span></label>
+                                                <label for="starpoint_10" class="label_star" title="5"><span class="blind">5점</span></label>
+                                                <span class="starpoint_bg"></span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="review_card_content">
+                                        <p class="content">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Veritatis impedit necessitatibus quod laboriosam quam quibusdam! Repellendus, et vel? Molestias cumque exercitationem recusandae adipisci nihil dignissimos reprehenderit tempora. Laudantium, dolor aliquid.</p>
+                                    </div>
+                                </div>
+                                <div class="col-2" style="text-align: right;">
+                                    <button type="button" class="btn-update btn btn-secondary btn-sm" class="btn_follower" data-bs-toggle="modal"data-bs-target="#ReviewModal">
+                                        수정
+                                   </button>
+                                   <button id="delete_button" type="button" onclick="handleDeleteReview()"class="btn-delete btn btn-secondary btn-sm">삭제</button>
+                                </div>
+                            </div>
+                        
                         </li>
+                        <li class="d-flex justify-content-between align-items-start mb-5">
+                            <div class="row">
+                                <div class="col-10">
+                                    <div class="fw-bold flex mb-1">
+                                        <span class="user">작성자</span> 
+                                        <div class="music_card_grade" style="margin-left: 16px;">
+                                            <span class="grade">3.5</span>
+                                            <div class="starpoint_wrap">
+                                                <div class="starpoint_box star_70">
+                                                <label for="starpoint_1" class="label_star" title="0.5"><span class="blind">0.5점</span></label>
+                                                <label for="starpoint_2" class="label_star" title="1"><span class="blind">1점</span></label>
+                                                <label for="starpoint_3" class="label_star" title="1.5"><span class="blind">1.5점</span></label>
+                                                <label for="starpoint_4" class="label_star" title="2"><span class="blind">2점</span></label>
+                                                <label for="starpoint_5" class="label_star" title="2.5"><span class="blind">2.5점</span></label>
+                                                <label for="starpoint_6" class="label_star" title="3"><span class="blind">3점</span></label>
+                                                <label for="starpoint_7" class="label_star" title="3.5"><span class="blind">3.5점</span></label>
+                                                <label for="starpoint_8" class="label_star" title="4"><span class="blind">4점</span></label>
+                                                <label for="starpoint_9" class="label_star" title="4.5"><span class="blind">4.5점</span></label>
+                                                <label for="starpoint_10" class="label_star" title="5"><span class="blind">5점</span></label>
+                                                <span class="starpoint_bg"></span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="review_card_content">
+                                        <p class="content">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Veritatis impedit necessitatibus quod laboriosam quam quibusdam! Repellendus, et vel? Molestias cumque exercitationem recusandae adipisci nihil dignissimos reprehenderit tempora. Laudantium, dolor aliquid.</p>
+                                    </div>
+                                </div>
+                                <div class="col-2" style="text-align: right;">
+                                    <button type="button" class="btn-update btn btn-secondary btn-sm" class="btn_follower" data-bs-toggle="modal"data-bs-target="#ReviewModal">
+                                        수정
+                                   </button>
+                                   <button id="delete_button" type="button" onclick="handleDeleteReview()"class="btn-delete btn btn-secondary btn-sm">삭제</button>
+                                </div>
+                            </div>
+                            <!-- <span class="badge bg-primary rounded-pill">별점</span> -->
+                        </li>
+                        
                       </ol>
                 </section>
+            </div>
+        </div>
+    </div>
+    <!-- modal -->
+    <div class="modal fade moreModel" id="ReviewModal" tabindex="-1" aria-labelledby="followingModalLabel"aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h1 class="modal-title fs-5 " id="followModalLabel">Review Edit</h1>
+                    <button type="button" class="btn_close" data-bs-dismiss="modal" aria-label="Close"><i class="bi bi-x-lg"></i></button>
+                </div>
+                <div class="modal-body">
+                    <div class="review_form">
+                        <div class="form_review_content mb-3">
+                            <label for="input_review_content" class="form-label">내용 :</label>
+                            <textarea class="form-control" id="input_review_content" rows="3"></textarea>
+                        </div>
+                        <div class="form_review_grade">
+                            <label for="input_review_content" class="form-label">평점</label>
+                            <input type="text" id="input_review_grade" class="form-control" placeholder="평점">
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary " onclick="handleUpdateReview()">Update</button>
+                  </div>
             </div>
         </div>
     </div>

--- a/static/css/music_detail.css
+++ b/static/css/music_detail.css
@@ -4,8 +4,17 @@
     margin-top: 30px;
 }
 
+.section_header{
+    width: 100%;
+    text-align: center;
+}
+
+.section_review_music{
+    margin-left: 150px;
+    margin-right: 150px;
+}
+
 .form-floating{
-    /* margin-top: 70px; */
     background-color: grey;
     width: 100%;
 }
@@ -17,7 +26,7 @@
 }
 
 .col-md-4{
-    width: 300px;
+    width: 400px;
     height: 300px;
 }
 
@@ -36,24 +45,47 @@
 
 .review{
     margin-top: 100px;
-    width: 800px;
-    justify-content: center;
-    align-content: center;
+    display: grid;
+    place-items: center;
 }
 
+.write_review{
+    margin-bottom: 50px;
+    text-align: center;
+}
 
 .container-2{
     display: flex;
     justify-content: center;
     align-content: center;
-    margin-right: 200px;
     margin-top: 70px;
     
 }
  
-
 .d-flex{
-    width: 800px;
+    width: 100%;
+}
+
+.text{
+    text-align: center;
+    margin-top: 40px;
+    margin-bottom: 60px;
+    font-weight: bold;
+    
+}
+
+.btn-delete{
+    background-color: #1ED760;
+    color: black;
+    font-weight: bold;
+    margin-left: 10px;
+}
+
+
+.btn-update{
+    background-color: #1ED760;
+    color: black;
+    font-weight: bold;
 }
 
 

--- a/static/js/music_detail.js
+++ b/static/js/music_detail.js
@@ -1,77 +1,258 @@
 document.addEventListener("DOMContentLoaded", function(){
-    console.log("로딩되었음")
     handleMock()
 
 });
 
+// url 불러오는 함수
+function getParams(params){
+    const url = window.location.href
+    const urlParams = new URL(url).searchParams;
+    const get_urlParams = urlParams.get(params);
+    return get_urlParams;
+}
+
+
+// 음원 상세 정보 불러오기
 async function handleMock(){
-    const response = await fetch('http://127.0.0.1:8000/musics/3/',{
+    url_detail_music = getParams("music");
+    const response = await fetch('http://127.0.0.1:8000/musics/'+url_detail_music,{
         headers: {
-          
-            "Authorization":"Bearer " + "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNjY3NjYzNzEyLCJpYXQiOjE2Njc2MjA1MTIsImp0aSI6ImZlYTRjOTQ4MmE5YjQ0ZmY4ZDBjODAyNDk5NjdjY2IxIiwidXNlcl9pZCI6MSwidXNlcm5hbWUiOiJsYXJhYW5uYSJ9.CSRNHtW5sNcMd_iALKdBfG6kGWSGhLAiYhfezUvvtjs"
+            "Authorization":"Bearer " + localStorage.getItem("access"),
         },
         method:'GET',
     })
 
     const response_json = await response.json() 
-    // response 값 변수에 담기
-    console.log(response_json)
-    let music = response_json
-    let review = response_json['reviews']
+
+    let music = response_json;
+    let review = response_json['reviews'];
     
-    let music_detail = document.getElementById("music_detail")
+    let music_detail = document.getElementById("music_detail");
     music_detail.innerHTML='';
     
     let new_music = document.createElement('div');
     new_music.className = 'sec section_recommend_music';
     new_music.innerHTML = `
-    <div class="section_header" style="width:80%">
-        <h2 class="section_title highlight">${music['id']} : ${music['title']} </h2>
+    <div class="section_header" >
+        <h2 class="section_title highlight">TRACK # ${music['id']} </h2>
     </div>
     <div class="container-2 text-center">
         <div class="music_content row">
             <div class="col-md-4">
                 <img src="${music['image']}" class="img-fluid rounded-start" alt="...">
+                <br/>
+                <h1 class="text">${music['artist']} - ${music['title']}</h1>
             </div>
-            <div class="col-md-4">
-                <div class="card-body">
-                <p class="text-muted">${music['title']}</p>
-                <p class="text-muted">${music['artist']}</p>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="review">
-        <div class="section_header">
-            <h2 class="section_title highlight">리뷰를 작성해주세요 :)</h2>
-        </div>
-        <div class="form-floating">
-            <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2" style="height: 100px"></textarea>
-            <label for="floatingTextarea">댓글을 남겨주세요!</label>
-        </div>
-        <div class="button_write">
-            <button type="button" class="btn_review_submit btn btn-success btn-lg">등록하기</button>
         </div>
     </div>
     `;
     music_detail.append(new_music);
    
-   
-    let review_list = document.getElementById("review_list")
+
+//  리뷰 목록 불러오기
+    let review_list = document.getElementById("review_list");
     review_list.innerHTML='';
     review.forEach(element => {
-    let new_review = document.createElement('div');
-    new_review.className = 'sec section_review_music';
-    new_review.innerHTML = `
-    <ol class="list-group" id="review_list">
-        <li class="d-flex justify-content-between align-items-start">
-          <div class="ms-2 me-auto">
-            <div class="fw-bold">${element['user']} : ${element['content']}</div>
-          </div>
-          <span class="badge bg-primary rounded-pill">${element['grade']}</span>
-        </li>
-    </ol>
-    `;
+        let new_review = document.createElement('li');
+        new_review.className = 'review_card mb-5';
+        new_review.id = 'review_'+element['id'];
+        new_review.innerHTML = `
+            <div class="row">
+                <div class="col-10">
+                    <div class="fw-bold flex mb-1">
+                        <span class="user">${element['user']}</span> 
+                        <div class="music_card_grade" style="margin-left: 16px;">
+                            <span class="grade">${element['grade']}</span>
+                            <div class="starpoint_wrap">
+                                <div class="starpoint_box star_${element['grade']*20}">
+                                    <label for="starpoint_1" class="label_star" title="0.5"><span class="blind">0.5점</span></label>
+                                    <label for="starpoint_2" class="label_star" title="1"><span class="blind">1점</span></label>
+                                    <label for="starpoint_3" class="label_star" title="1.5"><span class="blind">1.5점</span></label>
+                                    <label for="starpoint_4" class="label_star" title="2"><span class="blind">2점</span></label>
+                                    <label for="starpoint_5" class="label_star" title="2.5"><span class="blind">2.5점</span></label>
+                                    <label for="starpoint_6" class="label_star" title="3"><span class="blind">3점</span></label>
+                                    <label for="starpoint_7" class="label_star" title="3.5"><span class="blind">3.5점</span></label>
+                                    <label for="starpoint_8" class="label_star" title="4"><span class="blind">4점</span></label>
+                                    <label for="starpoint_9" class="label_star" title="4.5"><span class="blind">4.5점</span></label>
+                                    <label for="starpoint_10" class="label_star" title="5"><span class="blind">5점</span></label>
+                                    <span class="starpoint_bg"></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="review_card_content">
+                        <p class="content">${element['content']}</p>
+                    </div>
+                </div>
+                <div class="col-2" style="text-align: right;">
+                    <button type="button" class="btn-update btn btn-secondary btn-sm" class="btn_follower" data-bs-toggle="modal"data-bs-target="#ReviewModal">수정</button>
+                    <button id="delete_button" type="button" onclick="handleDeleteReview(this)"class="btn-delete btn btn-secondary btn-sm">삭제</button>
+                </div>
+            </div>
+        `;
     review_list.append(new_review);
+    });
+}
+
+
+// 리뷰 작성하기
+async function handleCreateReview() {
+
+    url_detail_music = getParams("music");
+
+    const content = document.getElementById("content").value;
+    const grade = document.getElementById("grade").value;
+    
+    const response = await fetch('http://127.0.0.1:8000/musics/'+url_detail_music+'/reviews/',{
+        method:'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            "Authorization":"Bearer " + localStorage.getItem("access"),
+        },
+        body: JSON.stringify({
+            content:content,
+            grade:grade
+        }),
+    }).then(response => {
+        if(!response.ok){
+            throw new Error(`${response.status} 에러가 발생했습니다.`);    
+        }
+        return response.json()
+    }).then(result => {
+        if(result['message']){
+            alert(result['message']);
+        }else{
+            element = result;
+            alert("리뷰 작성 완료되었습니다.");
+            let review_list = document.getElementById("review_list");
+            let new_review = document.createElement('li');
+            new_review.className = 'review_card mb-5';
+            new_review.id = 'review_'+element['id'];
+            new_review.innerHTML = `
+                <div class="row">
+                    <div class="col-10">
+                        <div class="fw-bold flex mb-1">
+                            <span class="user">${element['user']}</span> 
+                            <div class="music_card_grade" style="margin-left: 16px;">
+                                <span class="grade">${element['grade']}</span>
+                                <div class="starpoint_wrap">
+                                    <div class="starpoint_box star_${element['grade']*20}">
+                                        <label for="starpoint_1" class="label_star" title="0.5"><span class="blind">0.5점</span></label>
+                                        <label for="starpoint_2" class="label_star" title="1"><span class="blind">1점</span></label>
+                                        <label for="starpoint_3" class="label_star" title="1.5"><span class="blind">1.5점</span></label>
+                                        <label for="starpoint_4" class="label_star" title="2"><span class="blind">2점</span></label>
+                                        <label for="starpoint_5" class="label_star" title="2.5"><span class="blind">2.5점</span></label>
+                                        <label for="starpoint_6" class="label_star" title="3"><span class="blind">3점</span></label>
+                                        <label for="starpoint_7" class="label_star" title="3.5"><span class="blind">3.5점</span></label>
+                                        <label for="starpoint_8" class="label_star" title="4"><span class="blind">4점</span></label>
+                                        <label for="starpoint_9" class="label_star" title="4.5"><span class="blind">4.5점</span></label>
+                                        <label for="starpoint_10" class="label_star" title="5"><span class="blind">5점</span></label>
+                                        <span class="starpoint_bg"></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="review_card_content">
+                            <p class="content">${element['content']}</p>
+                        </div>
+                    </div>
+                    <div class="col-2" style="text-align: right;">
+                        <button type="button" class="btn-update btn btn-secondary btn-sm" class="btn_follower" data-bs-toggle="modal"data-bs-target="#ReviewModal">수정</button>
+                        <button id="delete_button" type="button" onclick="handleDeleteReview(this);"class="btn-delete btn btn-secondary btn-sm">삭제</button>
+                    </div>
+                </div>
+            `;
+            review_list.append(new_review);
+        }
+        
+    }).catch(error => {
+        alert("리뷰 작성에 실패하였습니다.\n자세한 내용은 관리자에게 문의해주세요.");
+        console.warn(error.message);
+    });
+}
+
+
+// 리뷰 삭제하기
+async function handleDeleteReview(el) {
+    review_id = el.closest(".review_card").getAttribute("id").split('_')[1];
+
+    const response = await fetch('http://127.0.0.1:8000/musics/reviews/'+review_id+'/',{
+        method:'DELETE',
+        headers: {
+            "Authorization":"Bearer " + localStorage.getItem("access"),
+        },
+    }).then(response => {
+        if(!response.ok){
+            throw new Error(`${response.status} 에러가 발생했습니다.`);    
+        }
+        return response;
+    }).then(async result => {
+        alert("리뷰가 삭제되었습니다.");
+        // 삭제 완료시 html review_card도 삭제
+        remove_review = document.getElementById("review_"+review_id);
+        remove_review.remove();
+    }).catch(async error => {
+        alert("리뷰 삭제에 실패하였습니다.\n자세한 내용은 관리자에게 문의해주세요.");
+        console.warn(error.message);
+    });
+}
+    
+
+// 리뷰 수정 - > 모달로 내용 불러오기
+$('#ReviewModal').on('show.bs.modal', function(event) {     
+    review_id = $(event.relatedTarget).closest(".review_card").attr("id").split('_')[1];
+    document.getElementById("ReviewModal").setAttribute("data-review",review_id);
+    review_content_text =document.getElementById("review_"+review_id).querySelector(".content").innerText;
+    document.getElementById("input_review_content").value = review_content_text;
+    review_content_grade =document.getElementById("review_"+review_id).querySelector(".grade").innerText;
+    document.getElementById("input_review_grade").value = review_content_grade;
+});
+
+
+// 리뷰 수정하기
+async function handleUpdateReview() {
+    review_id = document.getElementById("ReviewModal").getAttribute("data-review");
+    content =document.getElementById("ReviewModal").querySelector("#input_review_content").value;
+    grade =document.getElementById("ReviewModal").querySelector("#input_review_grade").value;
+    const response = await fetch('http://127.0.0.1:8000/musics/reviews/'+review_id+"/",{
+        method:'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+            "Authorization":"Bearer " + localStorage.getItem("access"),      
+        },
+        body: JSON.stringify({
+            content:content,
+            grade:grade
+        }),
+    }).then(response => {
+        if(!response.ok){
+            throw new Error(`${response.status} 에러가 발생했습니다.`);    
+        }
+        return response.json()
+    }).then(result => {
+        $("#ReviewModal").modal("hide");
+        alert("리뷰가 수정되었습니다.");
+        
+        // 수정된 내용 html에 다시 뿌려주기
+        document.getElementById("review_"+review_id).querySelector(".content").innerText = result['content'];
+        document.getElementById("review_"+review_id).querySelector(".grade").innerText = result['grade'];
+        document.getElementById("review_"+review_id).querySelector(".starpoint_wrap").innerHTML = `
+            <div class="starpoint_box star_${result['grade']*20}">
+                <label for="starpoint_1" class="label_star" title="0.5"><span class="blind">0.5점</span></label>
+                <label for="starpoint_2" class="label_star" title="1"><span class="blind">1점</span></label>
+                <label for="starpoint_3" class="label_star" title="1.5"><span class="blind">1.5점</span></label>
+                <label for="starpoint_4" class="label_star" title="2"><span class="blind">2점</span></label>
+                <label for="starpoint_5" class="label_star" title="2.5"><span class="blind">2.5점</span></label>
+                <label for="starpoint_6" class="label_star" title="3"><span class="blind">3점</span></label>
+                <label for="starpoint_7" class="label_star" title="3.5"><span class="blind">3.5점</span></label>
+                <label for="starpoint_8" class="label_star" title="4"><span class="blind">4점</span></label>
+                <label for="starpoint_9" class="label_star" title="4.5"><span class="blind">4.5점</span></label>
+                <label for="starpoint_10" class="label_star" title="5"><span class="blind">5점</span></label>
+                <span class="starpoint_bg"></span>
+            </div>
+        `        
+    }).catch(error => {
+        alert("리뷰 수정에 실패하였습니다.\n자세한 내용은 관리자에게 문의해주세요.");
+        console.warn(error.message);
     });
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/feature/27-music-review-api -> API

## 변경 사항

1. 음원 상세 페이지에서 음원의 상세 정보를 불러온다. (handleMock())
    - [x] 음원 정보 불러오기
    - [x] 이 음원에 작성된 리뷰 목록 불러오기
    - [x] 테스트 결과
![image](https://user-images.githubusercontent.com/113044908/200255319-3d6d2878-bfa4-4021-9272-2e13df0b4935.png)

2. 음원 상세 페이지에서 리뷰를 작성, 수정, 삭제가 가능하다.
    - [x] 리뷰 작성(handleCreateReview()), 리뷰 수정(handleUpdateReview()), 리뷰 삭제(handleDeleteReview())
    - [x] 리뷰 수정, 삭제는 리뷰 작성자만 가능하다.
    - [x] 리뷰 수정을 위해 모달창을 만들었고 , 이 모달창에서 리뷰 수정이 가능하다.
    <img width="959" alt="Screenshot 2022-11-07 at 4 57 45 PM" src="https://user-images.githubusercontent.com/113044908/200256056-aad782a2-df66-4613-9ee6-aa4b650a6783.png">
    
    - [x] 테스트 결과
<img width="795" alt="Screenshot 2022-11-07 at 4 54 16 PM" src="https://user-images.githubusercontent.com/113044908/200255496-72cadb30-3bce-4981-bd7a-f9844331979b.png">

