### PR TITLE
Fix : 음악 전체 목록페이지  링크  및 총평점 누락 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
                                         </div>
                                     </button>
                                     <ul class="dropdown-menu">
-                                        <a class="dropdown-item" href='#'>내 프로필</a>
+                                        <a class="dropdown-item" href='profile.html'>내 프로필</a>
                                         <a class="dropdown-item" href='#' onclick="handleLogout()">로그아웃</a>
                                     </ul>
                                 </div>

--- a/music_list.html
+++ b/music_list.html
@@ -60,7 +60,7 @@
                                         </div>
                                     </button>
                                     <ul class="dropdown-menu">
-                                        <a class="dropdown-item" href='#'>내 프로필</a>
+                                        <a class="dropdown-item" href='/profile.html'>내 프로필</a>
                                         <a class="dropdown-item" href='#' onclick="handleLogout()">로그아웃</a>
                                     </ul>
                                 </div>

--- a/static/js/mainAPI.js
+++ b/static/js/mainAPI.js
@@ -2,7 +2,7 @@ document.addEventListener("DOMContentLoaded", function(){
     handleMock()
 });
 async function handleMock(){
-    const response = await fetch('http://127.0.0.1:8000/musics/',{
+    const response = await fetch('http://127.0.0.1:8000/musics/recommend/',{
         headers: {
             "Authorization":"Bearer " + localStorage.getItem("access")
         },
@@ -38,7 +38,9 @@ function append_user_list(dataset,element){
                         </div>
                         <div class="profile_meta card_meta">
                             <div class="profile_username">
-                                <span class="username" id="username_1">${data['username']}</span>
+                                <a href='/profile.html?username=${data['username']}>
+                                    <span class="username" id="username_1">${data['username']}</span>
+                                </a>
                             </div>
                         </div>
                     </div>
@@ -57,7 +59,7 @@ function append_music_list(dataset,element){
         let new_item = document.createElement('div');
         new_item.className = 'col-lg-3 col-md-4 col-6';
         new_item.innerHTML = `
-                        <a href="#">
+                        <a href='/music_detail.html?music=${data['id']}'>
                             <div class='music_card' id="music_${data['id']}">
                                 <div class="card_header list_profile">
                                     <div class="music_album_images">

--- a/static/js/music.js
+++ b/static/js/music.js
@@ -7,13 +7,25 @@ async function handleMock(){
             "Authorization":"Bearer " + localStorage.getItem("access")
         },
         method:'GET',
-    })
+    }).then(response => {
+        if(!response.ok){
+            if(response.status==401){
+                alert("로그인 유저만 접근 가능합니다.")
+                location.href="/signin.html";
+            }
+            throw new Error(`${response.status} 에러가 발생했습니다.`);    
+        }
+        return response.json()
+    }).then(result => {
+        const musics = result;
     
-    const response_json = await response.json()
-    let musics = response_json
-
-    let all_musics_list = document.getElementById("all_musics_list").querySelector(".row")
-    append_music_list(musics,all_musics_list)
+        let all_musics_list = document.getElementById("all_musics_list").querySelector(".row")
+        append_music_list(musics,all_musics_list)
+    }).catch(error => {
+        console.warn(error.message)
+    });
+    
+   
 }
 function append_music_list(dataset,element){
     element.innerHTML='';

--- a/static/js/music.js
+++ b/static/js/music.js
@@ -21,7 +21,7 @@ function append_music_list(dataset,element){
         let new_item = document.createElement('div');
         new_item.className = 'col-lg-3 col-md-4 col-6';
         new_item.innerHTML = `
-                        <a href="#">
+                        <a href="/music_detail.html?music_${data['id']}">
                             <div class='music_card' id="music_${data['id']}">
                                 <div class="card_header list_profile">
                                     <div class="music_album_images">

--- a/static/js/music.js
+++ b/static/js/music.js
@@ -33,9 +33,9 @@ function append_music_list(dataset,element){
                                         <p class="music_card_title"><span class="title">${data['title']}</span></p>
                                         <p class="music_card_artist"><span class="artist">${data['artist']}</span></p>
                                         <div class="music_card_grade">
-                                            <span class="grade">5.0</span>
+                                            <span class="grade">${data['avg_grade']}</span>
                                             <div class="starpoint_wrap">
-                                                <div class="starpoint_box star_100">
+                                                <div class="starpoint_box star_${data['avg_grade']*20}">
                                                   <label for="starpoint_1" class="label_star" title="0.5"><span class="blind">0.5점</span></label>
                                                   <label for="starpoint_2" class="label_star" title="1"><span class="blind">1점</span></label>
                                                   <label for="starpoint_3" class="label_star" title="1.5"><span class="blind">1.5점</span></label>


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/musicListBug -> main

## 변경 사항
1.  전체음악목록 music_card에 총 평점 추가
2. 링크 추가
- navbar 내 프로필 : '/profile.html'로 이동
- music_card: '/music_detail.html?music=<music_id>'로 이동
3. 전체음악목록 페이지 로그인유저만 접근가능하게 처리
- 비로그인유저는 '/user/signin.html'로 이동


## 테스트 결과
![Screen Shot 2022-11-07 at 7 58 21 PM](https://user-images.githubusercontent.com/12287842/200294089-583c3f49-5ba1-4bd9-974b-c8a4faf0b4b2.png)
![Screen Shot 2022-11-07 at 8 37 27 PM](https://user-images.githubusercontent.com/12287842/200301104-c45be6a7-379c-4af4-9db4-1e70ea2eac1f.png)
