### PR TITLE
 Fix : 음원상세페이지로 이동하는 url을 입력할 때 예외처리 + Feat : 음원 상세정보에 총평점 보여주기

### DIFF
--- a/music_detail.html
+++ b/music_detail.html
@@ -71,6 +71,7 @@
                             <img src="https://i.scdn.co/image/ab67706f00000002381ef12e384968316222cbd5" class="img-fluid rounded-start" alt="...">
                             <br/>
                             <h1 class="text-muted">가수 : Rihanna</h1>
+                            <div id="music_card_avg_grade"></div>
                         </div>
                     </div>
                 </div>
@@ -204,7 +205,7 @@
     <footer>
 
     </footer>
-    
+
     <!-- JS 파일 -->
     <script src="static/js/music_detail.js"></script>
         

--- a/static/css/music_detail.css
+++ b/static/css/music_detail.css
@@ -41,11 +41,11 @@
 
 .button_write{
     text-align: center;
-    margin-bottom : 100px;
+    margin-bottom : 70px;
 }
 
 .review{
-    margin-top: 100px;
+    margin-top: 150px;
     display: grid;
     place-items: center;
 }
@@ -72,7 +72,7 @@
 .text{
     text-align: center;
     margin-top: 40px;
-    margin-bottom: 60px;
+    margin-bottom: 20px;
     font-weight: bold;
     
 }

--- a/static/js/music_detail.js
+++ b/static/js/music_detail.js
@@ -15,7 +15,7 @@ function getParams(params){
 
 // 음원 상세 정보 불러오기
 async function handleMock(){
-
+    
     // url이 ?music="music_id" 형태로 입력되지 않았을 때 에러메세지 출력
     url_detail_music = getParams("music");
     if (url_detail_music == undefined){
@@ -29,7 +29,11 @@ async function handleMock(){
         method:'GET',
     }).then(response => {
         if(!response.ok){
-            if(response.status==404){
+            if(response.status==401){
+                alert("로그인한 유저만 접근 가능합니다! 로그인해주세요 :)")
+                location.href="/signin.html";
+            }
+            else if(response.status==404){
                 alert("경로가 잘못되었습니다! 다시 입력해주세요 :)")
                 location.href="/index.html";
             }
@@ -42,7 +46,7 @@ async function handleMock(){
 
         let music = response_json;
         let review = response_json['reviews'];
-        
+
         let music_detail = document.getElementById("music_detail");
         music_detail.innerHTML='';
         
@@ -57,9 +61,25 @@ async function handleMock(){
             <div class="music_content row">
                 <div class="col-md-4">
                     <img src="${music['image']}" class="img-fluid rounded-start" alt="...">
-
-                    <br/>
                     <h1 class="text">${music['artist']} - ${music['title']}</h1>
+                    <div class="music_card_grade">
+                        <span class="grade">${music['avg_grade']}</span>
+                        <div class="starpoint_wrap">
+                            <div class="starpoint_box star_${music['avg_grade']*20}">
+                                <label for="starpoint_1" class="label_star" title="0.5"><span class="blind">0.5점</span></label>
+                                <label for="starpoint_2" class="label_star" title="1"><span class="blind">1점</span></label>
+                                <label for="starpoint_3" class="label_star" title="1.5"><span class="blind">1.5점</span></label>
+                                <label for="starpoint_4" class="label_star" title="2"><span class="blind">2점</span></label>
+                                <label for="starpoint_5" class="label_star" title="2.5"><span class="blind">2.5점</span></label>
+                                <label for="starpoint_6" class="label_star" title="3"><span class="blind">3점</span></label>
+                                <label for="starpoint_7" class="label_star" title="3.5"><span class="blind">3.5점</span></label>
+                                <label for="starpoint_8" class="label_star" title="4"><span class="blind">4점</span></label>
+                                <label for="starpoint_9" class="label_star" title="4.5"><span class="blind">4.5점</span></label>
+                                <label for="starpoint_10" class="label_star" title="5"><span class="blind">5점</span></label>
+                                <span class="starpoint_bg"></span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
fix/music_detail -> API

## 변경 사항
1.  - [x] 음원상세페이지로 이동하는 url을 입력할 때 예외처리 -> 로그인하지 않은 유저에게 401에러
<img width="524" alt="Screenshot 2022-11-07 at 11 58 58 PM" src="https://user-images.githubusercontent.com/113044908/200342096-87d8b18a-625a-4fc9-b084-5f7dd74bd246.png">

2. - [x] 음원 상세정보에 총평점도 같이  보여주기
<img width="952" alt="Screenshot 2022-11-07 at 11 59 22 PM" src="https://user-images.githubusercontent.com/113044908/200342181-37874b1c-b597-4e08-9981-49c2d73e3f31.png">


